### PR TITLE
Accept competition/recital/showcase as valid event types

### DIFF
--- a/functions/src/utils/validation.ts
+++ b/functions/src/utils/validation.ts
@@ -229,7 +229,7 @@ function validateISODateTime(dateTime: unknown): ValidationResult {
 }
 
 function validateEventType(type: unknown): ValidationResult {
-  const validTypes = ["social", "festival", "congress"];
+  const validTypes = ["social", "festival", "congress", "competition", "recital", "showcase"];
   if (!type || !validTypes.includes((type as string).toLowerCase())) {
     return { valid: false, message: `Event type must be one of: ${validTypes.join(", ")}` };
   }


### PR DESCRIPTION
Studio owners can now pick these from the create-event dropdown; without this the server rejected them with a 400 since validTypes only allowed social/festival/congress.