### PR TITLE
Add danceup-admin staging/production origins to CORS allowlist

### DIFF
--- a/functions/src/utils/http.ts
+++ b/functions/src/utils/http.ts
@@ -13,9 +13,11 @@ const ALLOWED_ORIGINS = new Set([
   // Staging
   "https://danceup-users-staging--staging-danceup.us-east4.hosted.app",
   "https://danceup-studio-owners--staging-danceup.us-east4.hosted.app",
+  "https://danceup-admin--staging-danceup.us-central1.hosted.app",
   // Production
   "https://danceup-users-production--production-danceup.us-east4.hosted.app",
   "https://danceup-studio-owners--production-danceup.us-east4.hosted.app",
+  "https://danceup-admin--production-danceup.us-central1.hosted.app",
   // Production custom domains
   "https://danceup.app",
   "https://studios.danceup.app",


### PR DESCRIPTION
danceup-admin now has real App Hosting backends for staging and production, but the allowlist only had dev origins for it — every request from the deployed staging/production admin panel would have been CORS-blocked.