### PR TITLE
Lower platform transaction fee from 1.5% to 0.75%

### DIFF
--- a/functions/src/routes/danceup-admin-finance.ts
+++ b/functions/src/routes/danceup-admin-finance.ts
@@ -157,7 +157,7 @@ app.get("/", async (req: Request, res: Response) => {
               displayAmount = charge.amount / 100;
               platformFee = bt.amount / 100;
             } else {
-              platformFee = Math.round((0.30 + displayAmount * 0.015) * 100) / 100;
+              platformFee = Math.round((0.30 + displayAmount * 0.0075) * 100) / 100;
             }
           } else if (bt.type === "application_fee") {
             // Charge not expanded — platform fee is still bt.amount
@@ -202,7 +202,7 @@ app.get("/", async (req: Request, res: Response) => {
         const charge = resolveCharge(bt.type, source);
         const platformFeeAmt = bt.type === "application_fee"
           ? bt.amount / 100                                    // direct: app fee amount
-          : Math.round((0.30 + (bt.amount / 100) * 0.015) * 100) / 100; // computed: $0.30 + 1.5%
+          : Math.round((0.30 + (bt.amount / 100) * 0.0075) * 100) / 100; // computed: $0.30 + 0.75%
         const grossAmt = charge
           ? charge.amount / 100
           : bt.type === "application_fee"

--- a/functions/src/services/stripe.service.ts
+++ b/functions/src/services/stripe.service.ts
@@ -2,13 +2,13 @@ import Stripe from "stripe";
 import { getSecret } from "../utils/secret-manager";
 
 export function platformFeeCents(amountCents: number): number {
-  return Math.round(amountCents * 0.015);
+  return Math.round(amountCents * 0.0075);
 }
 
 // Flat rate — Stripe subscriptions take a percentage (application_fee_percent) rather
-// than a cents amount, so this mirrors platformFeeCents' 1.5% for the subscription path.
+// than a cents amount, so this mirrors platformFeeCents' 0.75% for the subscription path.
 export function platformFeePercent(): number {
-  return 1.5;
+  return 0.75;
 }
 
 let stripeClient: Stripe | null = null;


### PR DESCRIPTION
Applies to both the flat-cents path (direct-charge PaymentIntents) and the percentage path (subscriptions), plus the admin finance dashboard's own independently-hardcoded fee-estimate formulas, which would otherwise have silently shown stale 1.5%-based numbers next to the real 0.75% charges.